### PR TITLE
Possible values of enum are now used as static methods

### DIFF
--- a/tests/AbstractEnumTest.php
+++ b/tests/AbstractEnumTest.php
@@ -63,9 +63,7 @@ class AbstractEnumTest extends TestCase
      */
     public function testGetConstList($includeDefault, $expected)
     {
-        $enum = new DummyWithDefaultEnum();
-
-        $this->assertEquals($expected, $enum->getConstList($includeDefault));
+        $this->assertEquals($expected, DummyWithDefaultEnum::getConstList($includeDefault));
     }
 
     public function dataForGetListTest()
@@ -109,5 +107,14 @@ class AbstractEnumTest extends TestCase
             [new DummyEnum(1), new DummyEnum(2), false],
             [new DummyEnum(1), new DummyWithDefaultEnum(1), false],
         ];
+    }
+
+    public function testExistenceOfTwoEnumClasses()
+    {
+        $constantsDummy = DummyEnum::getConstList();
+        $constantsSecondDummy = SecondDummyEnum::getConstList();
+
+        $this->assertEquals(['ONE' => 1, 'TWO' => 2], $constantsDummy);
+        $this->assertEquals(['TREE' => 3, 'FOUR' => 4], $constantsSecondDummy);
     }
 }

--- a/tests/SecondDummyEnum.php
+++ b/tests/SecondDummyEnum.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Paillechat\Enum\Tests;
+
+use Paillechat\Enum\Enum;
+use Paillechat\Enum\EnumValueToIntegerTrait;
+
+class SecondDummyEnum extends Enum
+{
+    use EnumValueToIntegerTrait;
+
+    const TREE = 3;
+    const FOUR = 4;
+}


### PR DESCRIPTION
Now it is possible to detect possible and default values of enum without instantiating concrete class. So enum is now behave more like real php type