### PR TITLE
Create static enum to represent singleton-based enums

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.0
   - 7.1
   - 7.2
   - nightly

--- a/README.md
+++ b/README.md
@@ -42,3 +42,51 @@ function proccessIssue(IssueType $type)
 }
 
 ```
+
+## Static constructor usage
+
+Public constant visibility is not necessary for this type of enum usage, protected is enough to work
+
+### Declare 
+```php
+<?php
+
+use Paillechat\Enum\Enum;
+
+/**
+ * @method static static ONE
+ * @method static static TWO
+ */
+class IssueType extends Enum 
+{
+    protected const ONE = 1;
+    protected const TWO = 2;
+} 
+
+# Now you can create enum via named static call
+$one = IssueType::ONE();
+```
+
+### Singleton-based enum
+```php
+<?php
+
+use Paillechat\Enum\StaticEnum;
+
+/**
+ * @method static static ONE
+ * @method static static TWO
+ */
+class IssueType extends StaticEnum 
+{
+    protected const ONE = 1;
+    protected const TWO = 2;
+} 
+
+# Now you can create enum via named static call
+$one1 = IssueType::ONE();
+$one2 = IssueType::ONE();
+
+# Now enums keep strict equality
+$one1 === $one2;
+```

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0.0"
+        "php": ">=7.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.4",

--- a/src/StaticEnum.php
+++ b/src/StaticEnum.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Paillechat\Enum;
+
+abstract class StaticEnum extends Enum
+{
+    /** @var StaticEnum[][] */
+    private static $instances = [];
+
+    private static $constReflections = [];
+
+    final protected static function createNamedInstance(string $name, $value)
+    {
+        $class = self::findParentClassForConst($name);
+
+        $key = self::getConstKey($class, $name);
+
+        if (!array_key_exists($key, self::$instances)) {
+            self::$instances[$key] = parent::createNamedInstance($name, $value);
+        }
+
+        return self::$instances[$key];
+    }
+
+    private static function getConstantReflection(string $class, string $name): \ReflectionClassConstant
+    {
+        $key = self::getConstKey($class, $name);
+        if (!array_key_exists($key, self::$constReflections)) {
+            $refl = self::getEnumReflection(static::class);
+
+            self::$constReflections[$key] = $refl->getReflectionConstant($name);
+        }
+
+        return self::$constReflections[$key];
+    }
+
+    private static function getConstKey(string $class, string $name): string
+    {
+        return $class.'::'.$name;
+    }
+
+    private static function findParentClassForConst(string $name): string
+    {
+        return self::getConstantReflection(static::class, $name)->getDeclaringClass()->getName();
+    }
+}

--- a/tests/AbstractEnumTest.php
+++ b/tests/AbstractEnumTest.php
@@ -123,6 +123,18 @@ class AbstractEnumTest extends TestCase
         ];
     }
 
+    public function testExtendingEnumKeepsBackwardEquality()
+    {
+        self::assertTrue(DummyEnum::ONE()->equals(DummyExtendingEnum::ONE()));
+        self::assertTrue(DummyExtendingEnum::ONE()->equals(DummyEnum::ONE()));
+    }
+
+    public function testDivergedEnumsAreNotEqual()
+    {
+        self::assertFalse(DummyDivergedEnum::ONE()->equals(DummyExtendingEnum::ONE()));
+        self::assertFalse(DummyExtendingEnum::ONE()->equals(DummyDivergedEnum::ONE()));
+    }
+
     public function testExistenceOfTwoEnumClasses()
     {
         $constantsDummy = DummyEnum::getConstList();

--- a/tests/DummyDivergedEnum.php
+++ b/tests/DummyDivergedEnum.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Paillechat\Enum\Tests;
+
+/**
+ * @method static static THREE
+ * @method static static FOUR
+ */
+final class DummyDivergedEnum extends DummyEnum
+{
+    const THREE = 3;
+    const FOUR = 4;
+}

--- a/tests/DummyEnum.php
+++ b/tests/DummyEnum.php
@@ -5,6 +5,10 @@ namespace Paillechat\Enum\Tests;
 use Paillechat\Enum\Enum;
 use Paillechat\Enum\EnumValueToIntegerTrait;
 
+/**
+ * @method static static ONE
+ * @method static static TWO
+ */
 class DummyEnum extends Enum
 {
     use EnumValueToIntegerTrait;

--- a/tests/DummyExtendingEnum.php
+++ b/tests/DummyExtendingEnum.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Paillechat\Enum\Tests;
+
+/**
+ * @method static static THREE
+ * @method static static FOUR
+ */
+final class DummyExtendingEnum extends DummyEnum
+{
+    const THREE = 3;
+    const FOUR = 4;
+}

--- a/tests/StaticEnumTest.php
+++ b/tests/StaticEnumTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Paillechat\Enum\Tests;
+
+use Paillechat\Enum\StaticEnum;
+use PHPUnit\Framework\TestCase;
+
+final class StaticEnumTest extends TestCase
+{
+    public function testStaticConstructorEnsuresStrictEquality()
+    {
+        $first = BaseStaticEnum::BASE_VAL_1();
+        $second = BaseStaticEnum::BASE_VAL_1();
+
+        self::assertSame($first, $second);
+    }
+
+    public function testInheritanceKeepsStrictEquality()
+    {
+        $first = BaseStaticEnum::BASE_VAL_1();
+        $second = ExtendingEnum::BASE_VAL_1();
+
+        self::assertSame($first, $second);
+    }
+
+    public function testStaticConstructorAllowsInternalFunctions()
+    {
+        $haystack = [BaseStaticEnum::BASE_VAL_1(), ExtendingEnum::BASE_VAL_2()];
+        $needle = ExtendingEnum::BASE_VAL_1();
+
+        self::assertContains($needle, $haystack);
+    }
+
+    public function testDivergenceBreaksEquality()
+    {
+        $first = DivergedStaticEnum::EXT_VAL_3();
+        $second = ExtendingEnum::EXT_VAL_3();
+
+        self::assertNotSame($first, $second);
+        self::assertNotEquals($first, $second);
+    }
+}
+
+/**
+ * @method static static BASE_VAL_1
+ * @method static static BASE_VAL_2
+ */
+class BaseStaticEnum extends StaticEnum
+{
+    protected const BASE_VAL_1 = 'val_1';
+    protected const BASE_VAL_2 = 'val_2';
+}
+
+/**
+ * @method static static EXT_VAL_3
+ * @method static static EXT_VAL_4
+ */
+final class ExtendingEnum extends BaseStaticEnum
+{
+    protected const EXT_VAL_3 = 'val_3';
+    protected const EXT_VAL_4 = 'val_4';
+}
+
+/**
+ * @method static static EXT_VAL_3
+ */
+class DivergedStaticEnum extends BaseStaticEnum
+{
+    protected const EXT_VAL_3 = 'val_3';
+}


### PR DESCRIPTION
Removed php 7.0 (entered security support only state), allowed to promote and use `protected` constant declaration for static based enums

### Improve equality checks

Now if
```php
class BaseEnum extends Enum 
{
  const VAL = 1;
}

class ExtEnum extends BaseEnum 
{
}
```

Then enum equality check will allow comparison like this
```php
BaseEnum::VAL()->equals(ExtEnum::VAL())
ExtEnum::VAL()->equals(BaseEnum::VAL())
```

### Singleton-based enum constructor

A bit slower than general constructor but allows strict comparisons of enums. It automatically makes working functions like `\in_array`

```php
public function testStaticConstructorAllowsInternalFunctions()
{
    $haystack = [BaseStaticEnum::BASE_VAL_1(), ExtendingEnum::BASE_VAL_2()];
    $needle = ExtendingEnum::BASE_VAL_1();

    self::assertContains($needle, $haystack);
}
```

Note that every enum declaration is different