### PR TITLE
Create BC-layer with deprecations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,9 @@
         "php": ">=7.0.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.4",
-        "squizlabs/php_codesniffer": "^2.8"
+        "phpunit/phpunit": "^6.5",
+        "squizlabs/php_codesniffer": "^2.8",
+        "symfony/phpunit-bridge": "^4.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit backupGlobals="false"
-    backupStaticAttributes="false"
-    colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    stopOnFailure="false"
-    bootstrap="vendor/autoload.php"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         colors="true"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
 >
+    <php>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak_vendors"/>
+    </php>
+
     <testsuites>
         <testsuite name="Paillechat Enum Test Suite">
             <directory>./tests/</directory>
@@ -20,4 +20,9 @@
             <directory suffix=".php">./src/</directory>
         </whitelist>
     </filter>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
+
 </phpunit>

--- a/src/EnumValueToIntegerTrait.php
+++ b/src/EnumValueToIntegerTrait.php
@@ -14,9 +14,17 @@ trait EnumValueToIntegerTrait
      * @return int
      *
      * @throws EnumException
+     *
+     * @deprecated integer-holding enums are deprecated and will be removed in 2.0
      */
     public function toInt(): int
     {
+        trigger_error(
+            __METHOD__ . ' is deprecated and will be removed in 2.0. ' .
+            'Use string-named enums.',
+            E_USER_DEPRECATED
+        );
+
         if (!is_integer($this->getValue())) {
             throw EnumException::becauseValueNotInteger();
         }

--- a/tests/AbstractEnumTest.php
+++ b/tests/AbstractEnumTest.php
@@ -5,68 +5,20 @@ namespace Paillechat\Enum\Tests;
 use Paillechat\Enum\Enum;
 use PHPUnit\Framework\TestCase;
 
-class AbstractEnumTest extends TestCase
+/**
+ * @covers \Paillechat\Enum\Enum
+ * @covers \Paillechat\Enum\EnumValueToIntegerTrait
+ */
+final class AbstractEnumTest extends TestCase
 {
-    public function testSuccess()
+    public function testCreateByNameConstructor()
     {
-        $enum = new DummyEnum(DummyEnum::ONE);
-
-        $this->assertInstanceOf(Enum::class, $enum);
+        self::assertEquals(DummyEnum::ONE(), DummyEnum::createByName('ONE'));
     }
 
-    /**
-     * @expectedException \Paillechat\Enum\Exception\EnumException
-     * @expectedExceptionMessage Value bar not exist in enum Paillechat\Enum\Tests\DummyEnum
-     */
-    public function testUnrecognisedValue()
+    public function testEquality()
     {
-        new DummyEnum('bar');
-    }
-
-    public function testDefaultValue()
-    {
-        $enum = new DummyWithDefaultEnum();
-
-        $this->assertEquals('bar', $enum);
-    }
-
-    /**
-     * @expectedException \Paillechat\Enum\Exception\EnumException
-     * @expectedExceptionMessage No default value in Paillechat\Enum\Tests\DummyEnum enum
-     */
-    public function testWhenNoDefault()
-    {
-        new DummyEnum();
-    }
-
-    public function testToInt()
-    {
-        $enum = new DummyEnum(DummyEnum::ONE);
-        $this->assertEquals(1, $enum->toInt());
-    }
-
-    /**
-     * @expectedException  \Paillechat\Enum\Exception\EnumException
-     * @expectedExceptionMessage Value no mismatch integer type
-     */
-    public function testCantBeInt()
-    {
-        $enum = new DummyWithDefaultEnum();
-        $enum->toInt();
-    }
-
-    public function testMagicStaticConstructorCreateEnum()
-    {
-        $this->assertEquals(new DummyEnum(DummyEnum::ONE), DummyEnum::ONE());
-    }
-
-    /**
-     * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage Unknown static constructor "THREE" for Paillechat\Enum\Tests\DummyEnum
-     */
-    public function testMagicStaticConstructorThrowsBadMethodCallException()
-    {
-        DummyEnum::THREE();
+        self::assertEquals(DummyEnum::ONE(), DummyEnum::ONE());
     }
 
     /**
@@ -80,7 +32,7 @@ class AbstractEnumTest extends TestCase
         $this->assertEquals($expected, DummyWithDefaultEnum::getConstList($includeDefault));
     }
 
-    public function dataForGetListTest()
+    public function dataForGetListTest(): array
     {
         return [
             [
@@ -101,28 +53,6 @@ class AbstractEnumTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider dataForTestEquals
-     *
-     * @param Enum $first
-     * @param Enum $second
-     * @param bool $expected
-     */
-    public function testEquals($first, $second, $expected)
-    {
-        $result = $first->equals($second);
-        $this->assertEquals($expected, $result);
-    }
-
-    public function dataForTestEquals()
-    {
-        return [
-            [new DummyEnum(1), new DummyEnum(1), true],
-            [new DummyEnum(1), new DummyEnum(2), false],
-            [new DummyEnum(1), new DummyWithDefaultEnum(1), false],
-        ];
-    }
-
     public function testExistenceOfTwoEnumClasses()
     {
         $constantsDummy = DummyEnum::getConstList();
@@ -130,5 +60,138 @@ class AbstractEnumTest extends TestCase
 
         $this->assertEquals(['ONE' => 1, 'TWO' => 2], $constantsDummy);
         $this->assertEquals(['THREE' => 3, 'FOUR' => 4], $constantsSecondDummy);
+    }
+
+    /**
+     * @expectedException \BadMethodCallException
+     * @expectedExceptionMessage Unknown static constructor "THREE" for Paillechat\Enum\Tests\DummyEnum
+     */
+    public function testMagicStaticConstructorThrowsBadMethodCallException()
+    {
+        /** @noinspection PhpUndefinedMethodInspection */
+        DummyEnum::THREE();
+    }
+
+    /**
+     * @expectedException \PHPUnit\Framework\Error\Notice
+     */
+    public function testCreateByNameConstructorThrowsNotice()
+    {
+        self::assertEquals(DummyEnum::ONE(), DummyEnum::createByName('One'));
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation %s. Use static constructors or createByName.
+     */
+    public function testSuccess()
+    {
+        $enum = new DummyEnum(DummyEnum::ONE);
+
+        $this->assertInstanceOf(Enum::class, $enum);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation %s. Use static constructors or createByName.
+     *
+     * @expectedException \Paillechat\Enum\Exception\EnumException
+     * @expectedExceptionMessage Value bar not exist in enum Paillechat\Enum\Tests\DummyEnum
+     */
+    public function testUnrecognisedValue()
+    {
+        new DummyEnum('bar');
+    }
+
+    /**
+     * @group legacy
+     *
+     * @expectedDeprecation %s. Use static constructors or createByName.
+     * @expectedDeprecation %s. Define argument explicitly.
+     * @expectedDeprecation %s. Cast to string instead.
+     */
+    public function testDefaultValue()
+    {
+        $enum = new DummyWithDefaultEnum();
+
+        $this->assertEquals('bar', $enum);
+    }
+
+    /**
+     * @group legacy
+     *
+     * @expectedDeprecation %s. Use static constructors or createByName.
+     * @expectedDeprecation %s. Define argument explicitly.
+     *
+     * @expectedException \Paillechat\Enum\Exception\EnumException
+     * @expectedExceptionMessage No default value in Paillechat\Enum\Tests\DummyEnum enum
+     */
+    public function testWhenNoDefault()
+    {
+        new DummyEnum();
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation %s. Use string-named enums.
+     * @expectedDeprecation %s. Cast to string instead.
+     *
+     * @throws \Paillechat\Enum\Exception\EnumException
+     */
+    public function testToInt()
+    {
+        $enum = new DummyEnum(DummyEnum::ONE);
+        $this->assertEquals(1, $enum->toInt());
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation %s. Define argument explicitly.
+     * @expectedDeprecation %s. Use string-named enums.
+     * @expectedDeprecation %s. Cast to string instead.
+     *
+     * @expectedException  \Paillechat\Enum\Exception\EnumException
+     * @expectedExceptionMessage Value no mismatch integer type
+     */
+    public function testCantBeInt()
+    {
+        $enum = new DummyWithDefaultEnum();
+        $enum->toInt();
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation %s. Use static constructors or createByName.
+     */
+    public function testMagicStaticConstructorCreateEnum()
+    {
+        $this->assertEquals(new DummyEnum(DummyEnum::ONE), DummyEnum::ONE());
+    }
+
+    /**
+     * @dataProvider getLegacyExamplesForEquality
+     *
+     * @param Enum $first
+     * @param Enum $second
+     * @param bool $expected
+     *
+     * @group legacy
+     *
+     * @expectedDeprecation %s. Use weak comparison instead.
+     * @expectedDeprecation %s. Cast to string instead.
+     */
+    public function testEquals($first, $second, $expected)
+    {
+        $result = $first->equals($second);
+        $this->assertEquals($expected, $result);
+    }
+
+    public function getLegacyExamplesForEquality(): array
+    {
+        return [
+            [@new DummyEnum(1), @new DummyEnum(1), true],
+            [@new DummyEnum(1), @new DummyEnum(2), false],
+            [@new DummyEnum(1), @new DummyWithDefaultEnum(1), false],
+        ];
     }
 }

--- a/tests/DummyEnum.php
+++ b/tests/DummyEnum.php
@@ -5,6 +5,9 @@ namespace Paillechat\Enum\Tests;
 use Paillechat\Enum\Enum;
 use Paillechat\Enum\EnumValueToIntegerTrait;
 
+/**
+ * @method static static ONE
+ */
 class DummyEnum extends Enum
 {
     use EnumValueToIntegerTrait;


### PR DESCRIPTION
* Created deprecations for method being removed in 2.0
* Created `createByName(string $name): static` method for smart serialization and deserialization (do not expect dynamic method call for deserializing name into `Enum::$name()` call, but `Enum::createByName($name)`
* Updated tests to expect deprecations